### PR TITLE
fix: hono-gateway and workers bun build outdir

### DIFF
--- a/apps/hono-gateway/package.json
+++ b/apps/hono-gateway/package.json
@@ -13,7 +13,7 @@
         }
     },
     "scripts": {
-        "build": "rm -rf dist && bun build src/index.ts --outfile dist/index.js --target node --format esm --minify --sourcemap && tsc --declaration --emitDeclarationOnly --outDir dist",
+        "build": "rm -rf dist && bun build ./src/index.ts --outdir ./dist --target node --format esm --minify --sourcemap && tsc --declaration --emitDeclarationOnly --outDir ./dist",
         "build:types": "tsc --declaration --emitDeclarationOnly --outDir dist/types src/router.ts",
         "check:types": "tsc --noEmit",
         "clean": "pnpm rimraf dist && pnpm rimraf node_modules && pnpm rimraf .turbo",

--- a/apps/workers/package.json
+++ b/apps/workers/package.json
@@ -10,7 +10,7 @@
         }
     },
     "scripts": {
-        "build": "rm -rf dist && bun build src/index.ts --outfile dist/index.js --target node --format esm --minify --sourcemap && tsc --declaration --emitDeclarationOnly --outDir dist",
+        "build": "rm -rf dist && bun build ./src/index.ts --outdir ./dist --target node --format esm --minify --sourcemap && tsc --declaration --emitDeclarationOnly --outDir ./dist",
         "check:types": "tsc --noEmit",
         "clean": "pnpm rimraf dist && pnpm rimraf node_modules && pnpm rimraf .turbo",
         "dev": "bun --watch --tsconfig-override tsconfig.dev.json src/index.ts",


### PR DESCRIPTION
## Proposed Changes

  - Update bun build commands for hono-gateway and workers apps
    - The `--outfile` flag for bun build without specifying an `--outdir` results in the artifacts being built to the src/ not dist/ 