### PR TITLE
build: spin up containers on run + dev script

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "db:stop": "docker compose stop postgres",
         "db:studio": "tooling/vault/inject.sh dev/hono-gateway pnpm --filter @phyt/data-access db:studio",
         "db:up": "docker compose up -d",
-        "dev": "concurrently \"pnpm dev:web\" \"pnpm dev:gw\" \"pnpm dev:wrk\"",
+        "dev": "tooling/scripts/dev.sh",
         "dev:gw": "tooling/vault/inject.sh dev/hono-gateway pnpm --filter @phyt/hono-gateway dev",
         "dev:web": "tooling/vault/inject.sh dev/web pnpm --filter @phyt/web dev",
         "dev:wrk": "tooling/vault/inject.sh dev/workers pnpm --filter @phyt/workers dev",

--- a/tooling/scripts/dev.sh
+++ b/tooling/scripts/dev.sh
@@ -3,6 +3,18 @@
 # Spin up containers
 docker compose up -d
 
+# Wait for containers to be ready
+echo "Waiting for containers to be ready..."
+sleep 5
+
+# Run database migrations
+echo "Running database migrations..."
+pnpm db:migrate
+
+# # WIP Deploy contracts for development
+# echo "Deploying contracts for development..."
+# pnpm contracts:deploy:dev
+
 # Function to cleanup on exit
 cleanup() {
     # Prevent double cleanup

--- a/tooling/scripts/dev.sh
+++ b/tooling/scripts/dev.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Spin up containers
+docker compose up -d
+
+# Function to cleanup on exit
+cleanup() {
+    echo "Stopping containers..."
+    
+    # Kill the concurrently process group
+    if [ ! -z "$CONCURRENT_PID" ]; then
+        kill -TERM $CONCURRENT_PID 2>/dev/null
+        wait $CONCURRENT_PID 2>/dev/null
+    fi
+    
+    # Stop docker containers
+    docker compose stop
+    
+    echo "Cleanup complete"
+    exit 0
+}
+
+# Trap SIGINT (Ctrl+C) and SIGTERM
+trap cleanup SIGINT SIGTERM
+
+# Start the dev processes and capture PID
+concurrently \
+    --kill-others-on-fail \
+    --prefix-colors "cyan,magenta,redBright" \
+    "pnpm dev:web" \
+    "pnpm dev:gw" \
+    "pnpm dev:wrk" &
+
+CONCURRENT_PID=$!
+
+# Wait for background processes
+wait $CONCURRENT_PID

--- a/tooling/scripts/dev.sh
+++ b/tooling/scripts/dev.sh
@@ -5,23 +5,31 @@ docker compose up -d
 
 # Function to cleanup on exit
 cleanup() {
+    # Prevent double cleanup
+    if [ "${CLEANUP_DONE:-}" = "true" ]; then
+        return
+    fi
+    CLEANUP_DONE=true
+    
     echo "Stopping containers..."
     
     # Kill the concurrently process group
     if [ ! -z "$CONCURRENT_PID" ]; then
         kill -TERM $CONCURRENT_PID 2>/dev/null
         wait $CONCURRENT_PID 2>/dev/null
+    else
+        # If CONCURRENT_PID is not set, try to kill any concurrently processes
+        pkill -f "concurrently.*pnpm dev:" 2>/dev/null || true
     fi
     
     # Stop docker containers
     docker compose stop
     
     echo "Cleanup complete"
-    exit 0
 }
 
-# Trap SIGINT (Ctrl+C) and SIGTERM
-trap cleanup SIGINT SIGTERM
+# Trap SIGINT (Ctrl+C), SIGTERM, and EXIT
+trap cleanup SIGINT SIGTERM EXIT
 
 # Start the dev processes and capture PID
 concurrently \


### PR DESCRIPTION
## Proposed Changes

  - Create dev script to spin up containers, inject env vars, and concurrently run apps
  - Spin down containers when SIGINT/SIGTERM 